### PR TITLE
Make Health Monitor System Agnostic

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,6 +1,10 @@
 {
     "healthMonitor": {
         "settings": {
+            "healthMonitorResource": {
+                "name": "Health Resource to Monitor",
+                "hint": "Resource to monitor (DnD uses 'system.attributes.hp', CoC uses 'system.attribs.hp', Simple World-Building uses 'system.health')"
+            },
             "useTokenName": {
                 "name": "Use Token Name",
                 "hint": "For unlinked tokens, token name will be used. For linked tokens, prototype token name will be used."

--- a/module.json
+++ b/module.json
@@ -13,18 +13,6 @@
         "minimum": "11",
         "verified": "11"
     },
-    "relationships": {
-        "systems": [
-            {
-                "id": "dnd5e",
-                "type": "system",
-                "compatibility": {
-                    "minimum": "2.0.0",
-                    "verified": "2.0.0"
-                }
-            }
-        ]
-    },
     "esmodules": [
         "./scripts/main.js"
     ],

--- a/scripts/health-monitor.js
+++ b/scripts/health-monitor.js
@@ -32,6 +32,14 @@ Hooks.once("ready", () => {
 class HealthMonitor {
     // Settings
     static registerSettings() {
+        game.settings.register(moduleID, "healthMonitorResource", {
+            name: game.i18n.localize("healthMonitor.settings.healthMonitorResource.name"),
+            hint: game.i18n.localize("healthMonitor.settings.healthMonitorResource.hint"),
+            scope: "world",
+            type: String,
+            default: "system.attributes.hp",
+            config: true
+        });
         game.settings.register(moduleID, "useTokenName", {
             name: game.i18n.localize("healthMonitor.settings.useTokenName.name"),
             hint: game.i18n.localize("healthMonitor.settings.useTokenName.hint"),
@@ -181,11 +189,13 @@ class HealthMonitor {
             // If Health Monitor disabled via control toggle, return
             if (!game.settings.get(moduleID, "hmToggle")) return;
 
+            const healthMonitorResource = game.settings.get(moduleID, 'healthMonitorResource');
+
             // If no HP change in update, return
-            const newHP = getProperty(diff, "system.attributes.hp");
+            const newHP = getProperty(diff, healthMonitorResource);
             if (!newHP) return;
 
-            const oldHP = getProperty(actor, "system.attributes.hp");
+            const oldHP = getProperty(actor, healthMonitorResource);
 
             // Calculate tempHP and HP deltas
             let tempDelta, valueDelta;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -34,6 +34,14 @@ const lg = x => console.log(x);
 
 Hooks.once('init', () => {
     // Register module settings.
+    game.settings.register(moduleID, "healthMonitorResource", {
+        name: game.i18n.localize("healthMonitor.settings.healthMonitorResource.name"),
+        hint: game.i18n.localize("healthMonitor.settings.healthMonitorResource.hint"),
+        scope: "world",
+        type: String,
+        default: "system.attributes.hp",
+        config: true
+    });
     game.settings.register(moduleID, 'useTokenName', {
         name: game.i18n.localize('healthMonitor.settings.useTokenName.name'),
         hint: game.i18n.localize('healthMonitor.settings.useTokenName.hint'),
@@ -190,12 +198,14 @@ Hooks.on("getSceneControlButtons", controls => {
 
 Hooks.on('preUpdateActor', async (actor, diff, options, userID) => {
     if (!game.settings.get(moduleID, 'hmToggle')) return;
-    
+
+    const healthMonitorResource = game.settings.get(moduleID, 'healthMonitorResource');
+
     // Calcuate HP deltas.
-    const newHP = foundry.utils.getProperty(diff, 'system.attributes.hp');
+    const newHP = foundry.utils.getProperty(diff, healthMonitorResource);
     if (!newHP) return;
 
-    const oldHP = actor.system.attributes.hp;
+    const oldHP = foundry.utils.getProperty(actor, healthMonitorResource);
     const deltas = {};
     if ('value' in newHP) deltas.hp = newHP.value - oldHP.value;
     if ('max' in newHP) deltas.max = newHP.max - oldHP.max


### PR DESCRIPTION
2nd half of the work to make system agnostic:

- add config option to list resource to monitor
- update references of resource to be monitored from config option